### PR TITLE
Generate KUBECONFIG in default k3s location

### DIFF
--- a/.devcontainer/features/k3s-on-host/updateContent.sh
+++ b/.devcontainer/features/k3s-on-host/updateContent.sh
@@ -447,6 +447,14 @@ function gen_kubeconfig_for_devcontainer() {
 ${kubeconfig}
 UPDATE_END" --disable_log
 
+    # Write the local kubeconfig to the default location in the devcontainer
+    [[ ! -d "/etc/rancher/k3s" ]] && run_a_script "mkdir -p /etc/rancher/k3s" --disable_log
+
+    run_a_script "tee /etc/rancher/k3s/k3s.yaml > /dev/null << UPDATE_END
+${kubeconfig}
+UPDATE_END" --disable_log
+
+
     info_log "Generated '$KUBECONFIG'."
     info_log "END: ${FUNCNAME[0]}"
 


### PR DESCRIPTION
Creates a duplicate k3s config file at the default k3s location `/etc/rancher/k3s/k3s.yaml` in addition to the KUBECONFIG requested output.

Test results:
![image](https://github.com/user-attachments/assets/49bdd1d5-4779-45bf-8180-5145027acd33)
